### PR TITLE
Add `--dry-run` and `--replace` flags run command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cli/cli/v2 v2.14.2
 	github.com/google/go-github/v45 v45.2.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/rwtodd/Go.Sed v0.0.0-20210816025313-55464686f9ef
 	github.com/yuin/goldmark v1.4.12
 	golang.org/x/oauth2 v0.0.0-20220630143837-2104d58473e0
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/rwtodd/Go.Sed v0.0.0-20210816025313-55464686f9ef h1:UD99BBEz19F21KhOFHLNAI6KodDWUvXaPr4Oqu8yMV8=
+github.com/rwtodd/Go.Sed v0.0.0-20210816025313-55464686f9ef/go.mod h1:8AEUvGVi2uQ5b24BIhcr0GCcpd/RNAFWaN2CJFrWIIQ=
 github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
 github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -18,7 +18,7 @@ func listCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			p, err := newParser()
 			if err != nil {
-				return errors.Wrap(err, "fail to read README file")
+				return err
 			}
 
 			snippets := p.Snippets()

--- a/internal/cmd/print.go
+++ b/internal/cmd/print.go
@@ -14,14 +14,12 @@ func printCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			p, err := newParser()
 			if err != nil {
-				return errors.Wrap(err, "fail to read README file")
+				return err
 			}
 
-			snippets := p.Snippets()
-
-			snippet, found := snippets.Lookup(args[0])
-			if !found {
-				return errors.Errorf("command %q not found; known command names: %s", args[0], snippets.Names())
+			snippet, err := lookup(p.Snippets(), args[0])
+			if err != nil {
+				return err
 			}
 
 			_, err = cmd.OutOrStdout().Write([]byte(snippet.Content()))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -41,8 +41,16 @@ func Root() *cobra.Command {
 func newParser() (*parser.Parser, error) {
 	source, err := os.ReadFile(filepath.Join(chdir, fileName))
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to read README file")
+		return nil, errors.WithStack(err)
 	}
 
 	return parser.New(source), nil
+}
+
+func lookup(snippets parser.Snippets, name string) (*parser.Snippet, error) {
+	snippet, found := snippets.Lookup(name)
+	if !found {
+		return nil, errors.Errorf("command %q not found; known command names: %s", name, snippets.Names())
+	}
+	return snippet, nil
 }

--- a/internal/cmd/tasks.go
+++ b/internal/cmd/tasks.go
@@ -15,21 +15,14 @@ func tasksCmd() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: like can omit because Args should do the validation.
-			if len(args) != 1 {
-				return cmd.Help()
-			}
-
 			p, err := newParser()
 			if err != nil {
-				return errors.Wrap(err, "fail to read README file")
+				return err
 			}
 
-			snippets := p.Snippets()
-
-			snippet, found := p.Snippets().Lookup(args[0])
-			if !found {
-				return errors.Errorf("command %q not found; known command names: %s", args[0], snippets.Names())
+			snippet, err := lookup(p.Snippets(), args[0])
+			if err != nil {
+				return err
 			}
 
 			tasksDef, err := tasks.GenerateFromShellCommand(

--- a/internal/parser/parser_snippets.go
+++ b/internal/parser/parser_snippets.go
@@ -60,7 +60,7 @@ func (p *Parser) Snippets() (result Snippets) {
 			}
 		}
 
-		result = append(result, s)
+		result = append(result, &s)
 	}
 
 	return result

--- a/internal/parser/snippet.go
+++ b/internal/parser/snippet.go
@@ -12,18 +12,22 @@ type Snippet struct {
 	language    string
 }
 
-func (s Snippet) Executable() string {
+func (s *Snippet) Executable() string {
 	if s.language != "" {
 		return s.language
 	}
 	return "sh"
 }
 
-func (s Snippet) Content() string {
+func (s *Snippet) Content() string {
 	return strings.TrimSpace(s.content)
 }
 
-func (s Snippet) Lines() []string {
+func (s *Snippet) ReplaceContent(val string) {
+	s.content = val
+}
+
+func (s *Snippet) Lines() []string {
 	var cmds []string
 
 	firstHasDollar := false
@@ -53,7 +57,7 @@ func (s Snippet) Lines() []string {
 	return cmds
 }
 
-func (s Snippet) FirstLine() string {
+func (s *Snippet) FirstLine() string {
 	cmds := s.Lines()
 	if len(cmds) > 0 {
 		return cmds[0]
@@ -63,24 +67,24 @@ func (s Snippet) FirstLine() string {
 
 var descriptionEndingsRe = regexp.MustCompile(`[:?!]$`)
 
-func (s Snippet) Description() string {
+func (s *Snippet) Description() string {
 	result := descriptionEndingsRe.ReplaceAllString(s.description, ".")
 	return result
 }
 
-func (s Snippet) Name() string {
+func (s *Snippet) Name() string {
 	return s.attributes["name"]
 }
 
-type Snippets []Snippet
+type Snippets []*Snippet
 
-func (s Snippets) Lookup(name string) (Snippet, bool) {
+func (s Snippets) Lookup(name string) (*Snippet, bool) {
 	for _, snippet := range s {
 		if snippet.Name() == name {
 			return snippet, true
 		}
 	}
-	return Snippet{}, false
+	return nil, false
 }
 
 func (s Snippets) Names() (result []string) {

--- a/internal/parser/snippet.go
+++ b/internal/parser/snippet.go
@@ -28,6 +28,7 @@ func (s Snippet) Lines() []string {
 
 	firstHasDollar := false
 	lines := strings.Split(s.content, "\n")
+
 	for _, line := range lines {
 		if strings.HasPrefix(line, "$") {
 			firstHasDollar = true

--- a/internal/runner/executable.go
+++ b/internal/runner/executable.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Executable interface {
+	DryRun(context.Context, io.Writer)
 	Run(context.Context) error
 }
 

--- a/internal/runner/go.go
+++ b/internal/runner/go.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +14,18 @@ import (
 type Go struct {
 	Base
 	Source string
+}
+
+var _ Executable = (*Shell)(nil)
+
+func (g Go) DryRun(ctx context.Context, w io.Writer) {
+	_, err := exec.LookPath("go")
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "failed to find %q executable: %s\n", "go", err)
+	}
+
+	_, _ = fmt.Fprintf(w, "// go run main.go in $TEMP\n\n")
+	_, _ = fmt.Fprintf(w, "%s\n", g.Source)
 }
 
 func (g Go) Run(ctx context.Context) error {

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -12,6 +13,19 @@ import (
 type Shell struct {
 	Base
 	Cmds []string
+}
+
+var _ Executable = (*Shell)(nil)
+
+func (s Shell) DryRun(ctx context.Context, w io.Writer) {
+	sh, ok := os.LookupEnv("SHELL")
+	if !ok {
+		sh = "/bin/sh"
+	}
+
+	for _, cmd := range s.Cmds {
+		_, _ = fmt.Fprintf(w, "%s in %s: %s\n", sh, s.Dir, cmd)
+	}
 }
 
 func (s Shell) Run(ctx context.Context) error {

--- a/internal/tasks/generate.go
+++ b/internal/tasks/generate.go
@@ -15,7 +15,7 @@ func Generate(descriptions ...TaskDescription) (*TaskConfiguration, error) {
 	}
 	v := validator.New()
 	if err := v.Struct(tc); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return &tc, nil
 }


### PR DESCRIPTION
`--dry-run` prints out what and where is executed:
```sh
$ go run main.go --chdir=./examples run --dry-run echo-hello                                                           
/bin/zsh in ./examples: echo "Hello, rdme!"
```

`--replace` allows to use sed to replace parts of the command:
```sh
$ go run main.go --chdir=examples run echo-hello
Hello, rdme!

$ go run main.go --chdir=examples run --replace="s/rdme/Gopher/" echo-hello
Hello, Gopher!
```

`--replace` uses [sed implementation in Go](https://github.com/rwtodd/Go.Sed).

Both flags can be combined so that if you want to run a snippet that requires some modifications, you can use `--dry-run` to verify that your `--replace` does what you expect.